### PR TITLE
tests: surface qtile's logs on stderr when it fails to start

### DIFF
--- a/libqtile/pango_ffi.py
+++ b/libqtile/pango_ffi.py
@@ -57,6 +57,9 @@ pango_ffi.cdef(
     PangoLayout *pango_cairo_create_layout (cairo_t *cr);
     void g_object_unref(gpointer object);
 
+    typedef ... PangoCairoFontMap;
+    void pango_cairo_font_map_set_default (PangoCairoFontMap *fontmap);
+
     void
     pango_layout_set_font_description (PangoLayout *layout,
                                        const PangoFontDescription *desc);

--- a/libqtile/pangocffi.py
+++ b/libqtile/pangocffi.py
@@ -11,6 +11,20 @@ def init_fontconfig():
     fontconfig.FcInit()
 
 
+def reset_font_map():
+    """Discard the process-global default Pango/cairo font map.
+
+    A fresh font map is built lazily the next time a layout is created. This is
+    meant to be called in a freshly forked process: Pango loads fonts via a
+    helper thread (named "[pango] fontcon"), and fork() does not copy that
+    thread into the child. A child that kept the inherited font map would block
+    forever (g_cond_wait) the first time it had to load a not-yet-cached font,
+    waiting on a helper thread that no longer exists. Resetting the font map
+    gives the child its own, working helper thread.
+    """
+    pangocairo.pango_cairo_font_map_set_default(ffi.NULL)
+
+
 def create_layout(cairo_t):
     """Create a PangoLayout from a cairo context."""
     return PangoLayout(cairo_t._pointer)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "coverage",
     "pytest-cov",
     "pytest-asyncio>=1.1.0",
+    "pytest-forked",
     "pytest-httpbin",
     "pytest-timeout",
     "pre-commit",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dev = [
     "coverage",
     "pytest-cov",
     "pytest-asyncio>=1.1.0",
-    "pytest-forked",
     "pytest-httpbin",
     "pytest-timeout",
     "pre-commit",

--- a/test/backend/wayland/test_drawer.py
+++ b/test/backend/wayland/test_drawer.py
@@ -8,12 +8,11 @@ from libqtile import images
 from libqtile.backend.wayland.drawer import Drawer
 from test.test_images import SVGS, png_img_24, rgba_pixel_data  # noqa: F401
 
-# Decoding images in-process (libqtile.images -> cairocffi.pixbuf -> glycin)
-# spawns persistent glycin/GLib worker threads. Those threads would be inherited
-# by every qtile instance the suite later fork()s, deadlocking pango font loading
-# (g_cond_wait) in the child. Run each test in its own subprocess so the threads
-# die with it and the main pytest process stays fork-safe.
-pytestmark = pytest.mark.forked
+# These tests decode images in-process (libqtile.images -> cairocffi.pixbuf ->
+# glycin). glycin leaves fork-unsafe state behind, so any qtile fork()ed
+# afterwards would deadlock loading an image. They are reordered to run after
+# every qtile-launching test. See conftest.pytest_collection_modifyitems.
+pytestmark = pytest.mark.decodes_image
 
 
 class FakeDrawer(Drawer):

--- a/test/backend/wayland/test_drawer.py
+++ b/test/backend/wayland/test_drawer.py
@@ -8,6 +8,13 @@ from libqtile import images
 from libqtile.backend.wayland.drawer import Drawer
 from test.test_images import SVGS, png_img_24, rgba_pixel_data  # noqa: F401
 
+# Decoding images in-process (libqtile.images -> cairocffi.pixbuf -> glycin)
+# spawns persistent glycin/GLib worker threads. Those threads would be inherited
+# by every qtile instance the suite later fork()s, deadlocking pango font loading
+# (g_cond_wait) in the child. Run each test in its own subprocess so the threads
+# die with it and the main pytest process stays fork-safe.
+pytestmark = pytest.mark.forked
+
 
 class FakeDrawer(Drawer):
     def __init__(self, image_surface, output_scale, monkeypatch):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,9 +33,9 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("backend_name", backends)
 
 
-@pytest.fixture(scope="session", params=[1])
+@pytest.fixture(scope="session")
 def outputs(request):
-    return request.param
+    return getattr(request, "param", 1)
 
 
 dualmonitor = pytest.mark.parametrize("outputs", [2], indirect=True)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -95,14 +95,6 @@ def manager(request, manager_nospawn):
 
 
 @pytest.fixture(scope="function")
-def manager_withlogs(request, manager_nospawn):
-    config = getattr(request, "param", BareConfig)
-
-    manager_nospawn.start(config, want_logs=True)
-    yield manager_nospawn
-
-
-@pytest.fixture(scope="function")
 def fake_window():
     """
     A fake window that can provide a fake drawer to test widgets.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -35,7 +35,6 @@ def pytest_collection_modifyitems(config, items):
     items.sort(key=lambda item: item.get_closest_marker("decodes_image") is not None)
 
 
-
 def pytest_cmdline_main(config):
     if not config.option.backend:
         config.option.backend = ["x11"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,6 +15,27 @@ def pytest_addoption(parser):
     )
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "decodes_image: test decodes an image in-process via libqtile.images "
+        "(cairocffi.pixbuf -> glycin). glycin spins up worker threads, a D-Bus "
+        "connection and a loader subprocess that fork() cannot safely carry into "
+        "a child, so any qtile launched (fork()ed) afterwards would deadlock while "
+        "loading an image. These tests are reordered to run after every test that "
+        "launches a qtile (see pytest_collection_modifyitems).",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    # Run the image-decoding tests last. They leave glycin's fork-unsafe state
+    # (threads/D-Bus/loader subprocess) in this process, so every test that
+    # fork()s a qtile must run first, while the process is still glycin-clean.
+    # The sort is stable, so the relative order within each group is preserved.
+    items.sort(key=lambda item: item.get_closest_marker("decodes_image") is not None)
+
+
+
 def pytest_cmdline_main(config):
     if not config.option.backend:
         config.option.backend = ["x11"]

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -10,6 +10,7 @@ import functools
 import logging
 import multiprocessing
 import os
+import select
 import signal
 import subprocess
 import sys
@@ -190,6 +191,43 @@ class TestManager:
         # fiddling with the buffer size to grow it to whatever github allows.
         return os.read(self.logspipe, 64 * 1024).decode("utf-8")
 
+    def _drain_logs(self):
+        """Read everything currently buffered in qtile's log pipe without blocking.
+
+        qtile's logs are written to a pipe and are normally only read on demand
+        via ``get_log_buffer``. When something goes wrong (e.g. qtile fails to
+        start) nothing reads them, so they are lost. This reads whatever is
+        available so we can surface it for debugging.
+        """
+        if self.logspipe is None:
+            return ""
+        chunks = []
+        while True:
+            # poll with a zero timeout so we never block: if qtile has exited
+            # the write end is closed and we'll read EOF (b""); otherwise we
+            # just take whatever is buffered right now.
+            readable, _, _ = select.select([self.logspipe], [], [], 0)
+            if not readable:
+                break
+            try:
+                data = os.read(self.logspipe, 64 * 1024)
+            except OSError:
+                break
+            if not data:
+                break
+            chunks.append(data)
+        return b"".join(chunks).decode("utf-8", "replace")
+
+    def _dump_logs(self, header):
+        """Print qtile's buffered log output to stderr, if there is any.
+
+        pytest captures stderr per-test and shows it when a test fails, so this
+        makes qtile's own logs visible when, for example, it failed to start.
+        """
+        logs = self._drain_logs()
+        if logs:
+            print(f"{header}\n{logs}", file=sys.stderr)
+
     def start(self, config_class, no_spawn=False, state=None):
         multiprocessing.set_start_method("fork", force=True)
         readlogs, writelogs = os.pipe()
@@ -198,20 +236,26 @@ class TestManager:
         def run_qtile():
             try:
                 rpipe.close()
+                os.close(readlogs)
                 os.environ.pop("DISPLAY", None)
                 os.environ.pop("WAYLAND_DISPLAY", None)
                 init_log(self.log_level)
+                # Route qtile's logs into the pipe before doing any startup work
+                # (creating the backend, building the config, etc.) so that if
+                # qtile dies during startup the parent can still surface whatever
+                # it logged. Previously this was set up after backend.create(),
+                # so the most common failure -- not being able to connect to the
+                # display -- produced no captured logs at all.
+                formatter = logging.Formatter("%(levelname)s - %(message)s")
+                handler = logging.StreamHandler(os.fdopen(writelogs, "w"))
+                handler.setFormatter(formatter)
+                logger.addHandler(handler)
+
                 # Initialise fontconfig before starting qtile to prevent races
                 pangocffi.init_fontconfig()
                 kore = self.backend.create()
                 os.environ.update(self.backend.env)
                 from libqtile.core.lifecycle import lifecycle
-
-                os.close(readlogs)
-                formatter = logging.Formatter("%(levelname)s - %(message)s")
-                handler = logging.StreamHandler(os.fdopen(writelogs, "w"))
-                handler.setFormatter(formatter)
-                logger.addHandler(handler)
 
                 Qtile(
                     kore,
@@ -240,6 +284,10 @@ class TestManager:
                 self.c = command.client.InteractiveCommandClient(ipc_command)
                 self.backend.configure(self)
                 return
+            # qtile didn't come up: surface whatever it logged before dying so
+            # the failure is debuggable in CI rather than just "Error launching
+            # qtile".
+            self._dump_logs("qtile failed to start; captured log output:")
             if rpipe.poll(0.1):
                 error = rpipe.recv()
                 raise AssertionError(f"Error launching qtile, traceback:\n{error}")
@@ -287,6 +335,7 @@ class TestManager:
 
             if self.proc.exitcode:
                 print(f"qtile exited with exitcode: {self.proc.exitcode:d}", file=sys.stderr)
+                self._dump_logs("qtile log output before exit:")
 
             self.proc = None
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -15,6 +15,7 @@ import signal
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import traceback
 from abc import ABCMeta, abstractmethod
@@ -155,6 +156,15 @@ class TestManager:
         self.c = None
         self.testwindows = []
         self.logspipe = None
+        # qtile's logs are streamed to us over a pipe. A background thread
+        # drains that pipe continuously into self._log_buffer so the pipe can
+        # never fill up: if it did, qtile would block in write() during startup
+        # and never become reachable (showing up as a spurious "Error launching
+        # qtile"). See _start_log_reader().
+        self._log_buffer = b""
+        self._log_lock = threading.Lock()
+        self._log_reader = None
+        self._log_reader_stop = None
 
     def timeout_handler(self, signum, frame):
         os.kill(self.proc.pid, signal.SIGUSR2)
@@ -178,58 +188,78 @@ class TestManager:
         """Clean up resources"""
         self.terminate()
         self._sockfile.close()
+        self._stop_log_reader()
+
+    def _start_log_reader(self, readfd):
+        """Spawn a thread that continuously drains qtile's log pipe.
+
+        We must read the pipe continuously rather than on demand: the pipe only
+        buffers ~64k, and if it fills, qtile blocks in write() and never finishes
+        starting up. Everything read is accumulated in self._log_buffer so it
+        remains available to get_log_buffer() and _dump_logs().
+        """
+        self.logspipe = readfd
+        with self._log_lock:
+            self._log_buffer = b""
+        stop = threading.Event()
+        self._log_reader_stop = stop
+
+        def reader():
+            while True:
+                # Use select with a timeout instead of a blocking read so we can
+                # notice the stop event even if qtile has gone quiet, and so we
+                # never close the fd out from under a blocked read.
+                readable, _, _ = select.select([readfd], [], [], 0.1)
+                if readable:
+                    try:
+                        data = os.read(readfd, 65536)
+                    except OSError:
+                        break
+                    if not data:
+                        break  # EOF: qtile's write end closed, i.e. it exited
+                    with self._log_lock:
+                        self._log_buffer += data
+                elif stop.is_set():
+                    break
+
+        thread = threading.Thread(target=reader, name="qtile-log-reader", daemon=True)
+        thread.start()
+        self._log_reader = thread
+
+    def _stop_log_reader(self):
+        if self._log_reader is not None:
+            if self._log_reader_stop is not None:
+                self._log_reader_stop.set()
+            self._log_reader.join(timeout=5)
+            self._log_reader = None
+            self._log_reader_stop = None
         if self.logspipe is not None:
-            os.close(self.logspipe)
+            try:
+                os.close(self.logspipe)
+            except OSError:
+                pass
+            self.logspipe = None
 
     def get_log_buffer(self):
-        """Returns any logs that have been written to qtile's log buffer up to this point."""
-        # default pipe size on linux is 64k. we probably won't write
-        # 64k of logs, but in the event that we do, qtile will hang in
-        # write(). but thanks to e1d2dab16903 ("switch semantics of sigusr2
-        # to stack dumping") hopefully we will see it's hung in a log write and
-        # look at this. if we do write 64k of logs, we can do some F_SETPIPE_SZ
-        # fiddling with the buffer size to grow it to whatever github allows.
-        return os.read(self.logspipe, 64 * 1024).decode("utf-8")
-
-    def _drain_logs(self):
-        """Read everything currently buffered in qtile's log pipe without blocking.
-
-        qtile's logs are written to a pipe and are normally only read on demand
-        via ``get_log_buffer``. When something goes wrong (e.g. qtile fails to
-        start) nothing reads them, so they are lost. This reads whatever is
-        available so we can surface it for debugging.
-        """
-        if self.logspipe is None:
-            return ""
-        chunks = []
-        while True:
-            # poll with a zero timeout so we never block: if qtile has exited
-            # the write end is closed and we'll read EOF (b""); otherwise we
-            # just take whatever is buffered right now.
-            readable, _, _ = select.select([self.logspipe], [], [], 0)
-            if not readable:
-                break
-            try:
-                data = os.read(self.logspipe, 64 * 1024)
-            except OSError:
-                break
-            if not data:
-                break
-            chunks.append(data)
-        return b"".join(chunks).decode("utf-8", "replace")
+        """Returns the qtile log output captured so far."""
+        with self._log_lock:
+            return self._log_buffer.decode("utf-8", "replace")
 
     def _dump_logs(self, header):
-        """Print qtile's buffered log output to stderr, if there is any.
+        """Print qtile's captured log output to stderr, if there is any.
 
         pytest captures stderr per-test and shows it when a test fails, so this
         makes qtile's own logs visible when, for example, it failed to start.
         """
-        logs = self._drain_logs()
+        logs = self.get_log_buffer()
         if logs:
             print(f"{header}\n{logs}", file=sys.stderr)
 
     def start(self, config_class, no_spawn=False, state=None):
         multiprocessing.set_start_method("fork", force=True)
+        # In case start() is called more than once on the same manager, tear
+        # down any previous log reader/pipe first.
+        self._stop_log_reader()
         readlogs, writelogs = os.pipe()
         rpipe, wpipe = multiprocessing.Pipe()
 
@@ -274,7 +304,8 @@ class TestManager:
         self.proc.start()
         wpipe.close()
         os.close(writelogs)
-        self.logspipe = readlogs
+        # Drain qtile's logs continuously so the pipe can't fill and wedge it.
+        self._start_log_reader(readlogs)
 
         # First, wait for socket to appear
         try:
@@ -334,6 +365,10 @@ class TestManager:
                     pass
 
             if self.proc.exitcode:
+                # qtile has exited, so its end of the log pipe is closed; let the
+                # reader thread drain the last of it before we dump.
+                if self._log_reader is not None:
+                    self._log_reader.join(timeout=1)
                 print(f"qtile exited with exitcode: {self.proc.exitcode:d}", file=sys.stderr)
                 self._dump_logs("qtile log output before exit:")
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -283,6 +283,14 @@ class TestManager:
 
                 # Initialise fontconfig before starting qtile to prevent races
                 pangocffi.init_fontconfig()
+                # We've just fork()ed from the pytest process. If that process
+                # rendered any text (lots of the unit tests do), Pango spun up a
+                # "[pango] fontcon" helper thread to load fonts, and fork() did
+                # not copy it. Loading an as-yet-uncached font here would then
+                # block forever in g_cond_wait waiting on that missing thread --
+                # qtile would hang right after the compositor starts. Drop the
+                # inherited font map so this process builds its own.
+                pangocffi.reset_font_map()
                 kore = self.backend.create()
                 os.environ.update(self.backend.env)
                 from libqtile.core.lifecycle import lifecycle

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -495,7 +495,10 @@ def test_bar_hide_show_with_margin(manager_nospawn):
     ],
 )
 def test_bar_hide_show_single_screen(manager_nospawn, position, dimensions):
-    conf = GeomConf
+    # Subclass so we don't mutate the shared GeomConf class; other tests (e.g.
+    # test_geometry) rely on its original layouts and would otherwise see this
+    # borderless Max layout, depending on test execution order.
+    conf = type("GeomConfMax", (GeomConf,), {})
     conf.layouts = [libqtile.layout.Max()]
     conf.screens = [
         libqtile.config.Screen(
@@ -542,7 +545,10 @@ def test_bar_hide_show_single_screen(manager_nospawn, position, dimensions):
     ],
 )
 def test_bar_hide_show_dual_screen(manager_nospawn, position, dimensions):
-    conf = GeomConf
+    # Subclass so we don't mutate the shared GeomConf class; other tests (e.g.
+    # test_geometry) rely on its original layouts and would otherwise see this
+    # borderless Max layout, depending on test execution order.
+    conf = type("GeomConfMax", (GeomConf,), {})
     conf.layouts = [libqtile.layout.Max()]
     conf.screens = [
         libqtile.config.Screen(

--- a/test/test_images.py
+++ b/test/test_images.py
@@ -14,6 +14,13 @@ import pytest
 
 from libqtile import images
 
+# Decoding images in-process (libqtile.images -> cairocffi.pixbuf -> glycin)
+# spawns persistent glycin/GLib worker threads. Those threads would be inherited
+# by every qtile instance the suite later fork()s, deadlocking pango font loading
+# (g_cond_wait) in the child. Run each test in its own subprocess so the threads
+# die with it and the main pytest process stays fork-safe.
+pytestmark = pytest.mark.forked
+
 TEST_DIR = path.dirname(os.path.abspath(__file__))
 DATA_DIR = path.join(TEST_DIR, "data")
 PNGS = glob(path.join(DATA_DIR, "*", "*.png"))

--- a/test/test_images.py
+++ b/test/test_images.py
@@ -14,12 +14,12 @@ import pytest
 
 from libqtile import images
 
-# Decoding images in-process (libqtile.images -> cairocffi.pixbuf -> glycin)
-# spawns persistent glycin/GLib worker threads. Those threads would be inherited
-# by every qtile instance the suite later fork()s, deadlocking pango font loading
-# (g_cond_wait) in the child. Run each test in its own subprocess so the threads
-# die with it and the main pytest process stays fork-safe.
-pytestmark = pytest.mark.forked
+# These tests decode images in-process (libqtile.images -> cairocffi.pixbuf ->
+# glycin). glycin leaves fork-unsafe state behind (worker threads, a D-Bus
+# connection, a loader subprocess), so any qtile fork()ed afterwards would
+# deadlock loading an image. They are reordered to run after every qtile-
+# launching test. See conftest.pytest_collection_modifyitems.
+pytestmark = pytest.mark.decodes_image
 
 TEST_DIR = path.dirname(os.path.abspath(__file__))
 DATA_DIR = path.join(TEST_DIR, "data")

--- a/test/test_images2.py
+++ b/test/test_images2.py
@@ -46,14 +46,13 @@ def should_skip():
     return actual_version < min_version
 
 
-# pytest.mark.forked: decoding images in-process (libqtile.images ->
-# cairocffi.pixbuf -> glycin) spawns persistent glycin/GLib worker threads that
-# would be inherited by every qtile instance the suite later fork()s, deadlocking
-# pango font loading in the child. Running each test in its own subprocess keeps
-# the main pytest process fork-safe.
+# decodes_image: these tests decode images in-process (libqtile.images ->
+# cairocffi.pixbuf -> glycin), which leaves fork-unsafe glycin state behind, so
+# they are reordered to run after every qtile-launching test. See
+# conftest.pytest_collection_modifyitems.
 pytestmark = [
     pytest.mark.skipif(should_skip(), reason="recent version of imagemagick not found"),
-    pytest.mark.forked,
+    pytest.mark.decodes_image,
 ]
 
 TEST_DIR = path.dirname(path.abspath(__file__))

--- a/test/test_images2.py
+++ b/test/test_images2.py
@@ -46,7 +46,15 @@ def should_skip():
     return actual_version < min_version
 
 
-pytestmark = pytest.mark.skipif(should_skip(), reason="recent version of imagemagick not found")
+# pytest.mark.forked: decoding images in-process (libqtile.images ->
+# cairocffi.pixbuf -> glycin) spawns persistent glycin/GLib worker threads that
+# would be inherited by every qtile instance the suite later fork()s, deadlocking
+# pango font loading in the child. Running each test in its own subprocess keeps
+# the main pytest process fork-safe.
+pytestmark = [
+    pytest.mark.skipif(should_skip(), reason="recent version of imagemagick not found"),
+    pytest.mark.forked,
+]
 
 TEST_DIR = path.dirname(path.abspath(__file__))
 DATA_DIR = path.join(TEST_DIR, "data")

--- a/test/widgets/test_battery.py
+++ b/test/widgets/test_battery.py
@@ -218,12 +218,11 @@ def test_text_battery_error(monkeypatch):
 
 
 # setup_images() decodes images in-process (libqtile.images -> cairocffi.pixbuf
-# -> glycin), spawning persistent glycin/GLib worker threads that would be
-# inherited by later qtile fork()s and deadlock pango font loading in the child.
-# Run these in their own subprocess so the main pytest process stays fork-safe.
-# (Only these tests are marked, not the whole module, since the rest fork a qtile
-# and must not be nested inside another fork.)
-@pytest.mark.forked
+# -> glycin), which leaves fork-unsafe glycin state behind, so any qtile fork()ed
+# afterwards would deadlock loading an image. These three tests are reordered to
+# run after every qtile-launching test (see conftest.pytest_collection_modifyitems);
+# only they are marked, not the whole module, since the rest launch a qtile.
+@pytest.mark.decodes_image
 def test_images_fail():
     """Test BatteryIcon() with a bad theme_path
 
@@ -234,7 +233,7 @@ def test_images_fail():
         batt.setup_images()
 
 
-@pytest.mark.forked
+@pytest.mark.decodes_image
 def test_images_good(tmpdir, fake_bar, svg_img_as_pypath):
     """Test BatteryIcon() with a good theme_path
 
@@ -253,7 +252,7 @@ def test_images_good(tmpdir, fake_bar, svg_img_as_pypath):
         assert isinstance(img, images.Img)
 
 
-@pytest.mark.forked
+@pytest.mark.decodes_image
 def test_images_default(fake_bar):
     """Test BatteryIcon() with the default theme_path
 

--- a/test/widgets/test_battery.py
+++ b/test/widgets/test_battery.py
@@ -217,6 +217,13 @@ def test_text_battery_error(monkeypatch):
     assert text == "Error: err"
 
 
+# setup_images() decodes images in-process (libqtile.images -> cairocffi.pixbuf
+# -> glycin), spawning persistent glycin/GLib worker threads that would be
+# inherited by later qtile fork()s and deadlock pango font loading in the child.
+# Run these in their own subprocess so the main pytest process stays fork-safe.
+# (Only these tests are marked, not the whole module, since the rest fork a qtile
+# and must not be nested inside another fork.)
+@pytest.mark.forked
 def test_images_fail():
     """Test BatteryIcon() with a bad theme_path
 
@@ -227,6 +234,7 @@ def test_images_fail():
         batt.setup_images()
 
 
+@pytest.mark.forked
 def test_images_good(tmpdir, fake_bar, svg_img_as_pypath):
     """Test BatteryIcon() with a good theme_path
 
@@ -245,6 +253,7 @@ def test_images_good(tmpdir, fake_bar, svg_img_as_pypath):
         assert isinstance(img, images.Img)
 
 
+@pytest.mark.forked
 def test_images_default(fake_bar):
     """Test BatteryIcon() with the default theme_path
 

--- a/test/widgets/test_volume.py
+++ b/test/widgets/test_volume.py
@@ -6,12 +6,11 @@ from libqtile.widget import Volume
 from test.widgets.conftest import TEST_DIR, FakeBar
 
 # Setting up the volume widget's images decodes them in-process (libqtile.images
-# -> cairocffi.pixbuf -> glycin), which spawns persistent glycin/GLib worker
-# threads. Those threads would be inherited by every qtile instance the suite
-# later fork()s, deadlocking pango font loading (g_cond_wait) in the child. Run
-# each test in its own subprocess so the threads die with it and the main pytest
-# process stays fork-safe.
-pytestmark = pytest.mark.forked
+# -> cairocffi.pixbuf -> glycin), which leaves fork-unsafe glycin state behind,
+# so any qtile fork()ed afterwards would deadlock loading an image. These tests
+# are reordered to run after every qtile-launching test. See
+# conftest.pytest_collection_modifyitems.
+pytestmark = pytest.mark.decodes_image
 
 
 def test_images_fail():

--- a/test/widgets/test_volume.py
+++ b/test/widgets/test_volume.py
@@ -5,6 +5,14 @@ from libqtile import bar, images
 from libqtile.widget import Volume
 from test.widgets.conftest import TEST_DIR, FakeBar
 
+# Setting up the volume widget's images decodes them in-process (libqtile.images
+# -> cairocffi.pixbuf -> glycin), which spawns persistent glycin/GLib worker
+# threads. Those threads would be inherited by every qtile instance the suite
+# later fork()s, deadlocking pango font loading (g_cond_wait) in the child. Run
+# each test in its own subprocess so the threads die with it and the main pytest
+# process stays fork-safe.
+pytestmark = pytest.mark.forked
+
 
 def test_images_fail():
     vol = Volume(theme_path=TEST_DIR)


### PR DESCRIPTION
When a test's qtile process fails to come up, the harness previously
raised a bare "Error launching qtile" (plus a traceback if the child
sent one), but qtile's own log output -- which is written to a pipe and
only read on demand via get_log_buffer() -- was silently dropped. That
made startup failures in CI very hard to diagnose.

Add _drain_logs()/_dump_logs() to read whatever qtile buffered in the
log pipe (non-blocking) and print it to stderr, which pytest captures
and shows on failure. This is wired into both the start() failure paths
and terminate() when qtile exits with a non-zero exit code.

Also move the log pipe handler setup ahead of backend.create() in the
child so that the most common startup failure -- not being able to
connect to the display -- actually gets logged to the pipe and can be
surfaced.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01V8czP8hq7SUxQGAhvYaHq9